### PR TITLE
yii2 has deprecated fxp-asset-manager

### DIFF
--- a/HandlebarsAsset.php
+++ b/HandlebarsAsset.php
@@ -1,17 +1,12 @@
 <?php
+
 namespace x1\handlebars;
 
 class HandlebarsAsset extends \yii\web\AssetBundle
 {
-	public $sourcePath = '@vendor/bower/handlebars';
-	
-	public $js         = [
-		'handlebars.js' => 'handlebars.min.js',
-	];
+    public $sourcePath = '@bower/handlebars';
 
-	public $css        = [
-	];
-
-	public $depends = [
-	];
+    public $js         = [
+        'handlebars.js' => 'handlebars.min.js',
+    ];
 }


### PR DESCRIPTION
Yii2 has stopped using FXP asset manager to manage assets, therefore this asset is not in "@vendor/bower/handlebars" folder any more... it is actually always in "@bower/handlebars" folder